### PR TITLE
Build before running tests in the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,7 @@ jobs:
       - run: npm ci
       - run: npm run lint
       - run: npm run typecheck
+      - run: npm run build
       - run: npx vitest run
       # prepublishOnly builds dist/; provenance is attached automatically
       # when publishing via a configured npm trusted publisher.


### PR DESCRIPTION
The release run for v6.0.0 failed because the CLI tests exercise dist/cli.js, which is gitignored and never built in release.yml. Adds the missing build step, mirroring ci.yml.